### PR TITLE
Fix broken links/typo in Lesson Content tab

### DIFF
--- a/lessons/misc/intro-bash/lesson.md
+++ b/lessons/misc/intro-bash/lesson.md
@@ -10,7 +10,7 @@ tags:
  - **Authors**: James Santangelo and Ahmed Hasan, based heavily on [material from John Ladan](https://github.com/UofTCoders/studyGroup/blob/gh-pages/lessons/misc/bash-intro/lesson.md) and a fourth year Genomics course bash primer written and delivered by Rob Ness and Ahmed Hasan.
  - **Research field**: Biology
  - **Lesson topic**: Introduction to shells and the command-line with bash.
- - **Lesson content URL**: <https://github.com/utm-coders/studyGroup/tree/gh-pages/lessons/misc/bash-intro/>
+ - **Lesson content URL**: <https://github.com/utm-coders/studyGroup/tree/gh-pages/lessons/misc/intro-bash>
 
 In this tutorial, we cover the basics of interacting with a computer using Bash (the Bourne Again Shell). You may have heard the terms "command line", "terminal", "console", "shell", "interactive prompt", "git-bash", etc. To be imprecise, they all refer to using the keyboard to control your computer by typing commands.
 

--- a/lessons/misc/intro-git/lesson.md
+++ b/lessons/misc/intro-git/lesson.md
@@ -10,7 +10,7 @@ tags:
  - **Authors**: Ahmed Hasan and James Santangelo, based very heavily on [material by Luke Johnston](https://github.com/UofTCoders/studyGroup/blob/gh-pages/lessons/git/intro/lesson.md). 
  - **Research field**: Biology
  - **Lesson topic**: Introduction to Git and GitHub
- - **Lesson content URL**: <https://github.com/utm-coders/studyGroup/tree/gh-pages/lessons/misc/git-intro/>
+ - **Lesson content URL**: <https://github.com/utm-coders/studyGroup/tree/gh-pages/lessons/misc/intro-git>
 
 In this tutorial, we cover the basics of version control with Git and touch on using GitHub for collaboration.
 

--- a/lessons/r/ggplot2/lesson.md
+++ b/lessons/r/ggplot2/lesson.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: 'Intro to R'
+title: 'Intro to data visualization with ggplot2'
 visible: true
 tags:
   - r
@@ -10,7 +10,7 @@ tags:
  - **Authors**: Ahmed Hasan and James Santangelo, borrowing heavily from Joel Ostblom
  - **Research field**: Biology
  - **Lesson topic**: Data visualization in R with `ggplot2`
- - **Lesson content URL**: <https://github.com/utm-coders/studyGroup/tree/gh-pages/lessons/r/intro>
+ - **Lesson content URL**: <https://github.com/utm-coders/studyGroup/tree/gh-pages/lessons/r/ggplot2>
 
 ## Preface: ##
 


### PR DESCRIPTION
- Fixed mislabelled ggplot2 lesson (was still labelled as Intro to R)
- Fixed broken lesson content links in both Bash and Git lessons
- Corrected lesson material link in ggplot2 lesson